### PR TITLE
feat: Aaditya/close codes

### DIFF
--- a/api/chat.go
+++ b/api/chat.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net/http"
 	"strings"
 	"time"
 
@@ -22,7 +21,8 @@ func JoinChat() echo.HandlerFunc {
 		channel := c.FormValue("channel")
 		validChannel := globals.IsChannelNameValid(channel)
 		if name == "" || !validChannel {
-			return c.String(http.StatusBadRequest, "Name and/or channel missing")
+			return utils.SendBadRequestMessage(c, "Name and/or channel missing")
+			// return c.String(http.StatusBadRequest, "Name and/or channel missing")
 		}
 		userID := c.FormValue("userID")
 		if db.CheckValidActiveUserID(userID) {
@@ -57,11 +57,11 @@ func ReceivedFrontendUserInfo() echo.HandlerFunc {
 		info := new(models.UserInfo)
 		e := c.Bind(info)
 		if e != nil {
-			return c.String(http.StatusBadRequest, "Wrongly formatted info")
+			return utils.SendBadRequestMessage(c, "Wrongly formatted info")
 		} else if info.UserID != db.GetUserID(info.Username) {
-			return c.String(http.StatusBadRequest, "Wrong user id and/or username")
+			return utils.SendBadRequestMessage(c, "Wrong user id and/or username")
 		} else if !globals.IsChannelNameValid(info.Channel) {
-			return c.String(http.StatusBadRequest, "Wrong channel name")
+			return utils.SendBadRequestMessage(c, "Wrong channel name")
 		}
 		//further processing
 		utils.SendUserInfoToSlack(*info)
@@ -76,12 +76,12 @@ func LeaveChat() echo.HandlerFunc {
 			// close web socket in sync with the chatWS functions
 			status := utils.CloseWebsocketAndCleanByUserID(userID)
 			if !status {
-				return c.String(http.StatusInternalServerError, "An internal server error has occurred")
+				return utils.SendInternalServerErrorCloseMessage(c, "An internal server error has occurred")
 			}
 			db.ChangeActiveUserToInactive(userID)
-			return c.String(http.StatusOK, "Thank you for visiting MDG Chat. We wish to have you again soon")
+			return utils.SendNormalCloseMessage(c, "Thank you for visiting MDG Chat. We wish to have you again soon")
 		} else {
-			return c.String(http.StatusBadRequest, "Wrong user ID")
+			return utils.SendBadRequestMessage(c, "Wrong user ID")
 		}
 	}
 }

--- a/api/utils/chatWS.go
+++ b/api/utils/chatWS.go
@@ -376,3 +376,46 @@ func SendConflictMessage(c echo.Context, reason string) error {
 	}
 	return nil;
 }
+
+func SendBadRequestMessage(c echo.Context, reason string) error {
+	ws, err := upgrader.Upgrade(c.Response().Writer, c.Request(), nil)
+	if err != nil {
+		return err 
+	}
+	defer ws.Close()
+	closeCode := websocket.CloseInvalidFramePayloadData
+	closeMessage := websocket.FormatCloseMessage(closeCode, reason)
+	if err := ws.WriteMessage(websocket.CloseMessage, closeMessage); err != nil {
+		return err
+	}
+	return nil;
+}
+
+func SendNormalCloseMessage(c echo.Context, reason string) error {
+	ws, err := upgrader.Upgrade(c.Response().Writer, c.Request(), nil)
+	if err != nil {
+		return err 
+	}
+	defer ws.Close()
+	closeCode := websocket.CloseNormalClosure
+	closeMessage := websocket.FormatCloseMessage(closeCode, reason)
+	if err := ws.WriteMessage(websocket.CloseMessage, closeMessage); err != nil {
+		return err
+	}
+	return nil;
+}
+
+func SendInternalServerErrorCloseMessage(c echo.Context, reason string) error {
+	ws, err := upgrader.Upgrade(c.Response().Writer, c.Request(), nil)
+	if err != nil {
+		return err 
+	}
+	defer ws.Close()
+	closeCode := websocket.CloseInternalServerErr
+	closeMessage := websocket.FormatCloseMessage(closeCode, reason)
+	if err := ws.WriteMessage(websocket.CloseMessage, closeMessage); err != nil {
+		return err
+	}
+	return nil;
+}
+


### PR DESCRIPTION
These changes incorporate a mechanism where instead of sending http protocool codes, we are using standard websocket close codes after immediately opening the server so that the frontend client can catch the close code.

a list of standard close codes can be found [here](https://github.com/Luka967/websocket-close-codes).

5 new functions have been made in the file chatWS.go , and they are called from the chat.go file, in the functions joinchat and leave chat respectively.